### PR TITLE
WitToKotlin: Use ByteArray instead of Array<Byte>

### DIFF
--- a/component-model/src/wasmTest/kotlin/org/kowasm/componentmodel/WitToKotlin.kt
+++ b/component-model/src/wasmTest/kotlin/org/kowasm/componentmodel/WitToKotlin.kt
@@ -241,7 +241,7 @@ val tuple: Pair<Int, String> = Pair(0, "")
  * For bytes, Kotlin array seems like a better fit (efficiency).
  * For other use cases, let's maybe use Kotlin list for now.
  */
-val listOfBytes : Array<Byte> = arrayOf()
+val listOfBytes : ByteArray = byteArrayOf()
 val list: List<String> = listOf()
 
 /**


### PR DESCRIPTION
`Array<Byte>` has the same boxing issue as `List<Byte>`